### PR TITLE
feat: add sock file path as target param

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -81,7 +81,7 @@ func (p DockerProvider) GetDefaultTargets() (*[]provider.ProviderTarget, error) 
 		{
 			Name:         "local",
 			ProviderInfo: info,
-			Options:      "{\"Container Image\": \"daytonaio/workspace-project\"}",
+			Options:      "{\n\t\"Container Image\": \"daytonaio/workspace-project\",\n\t\"Sock Path\": \"/var/run/docker.sock\"\n}",
 		},
 	}
 	return &defaultTargets, nil

--- a/pkg/types/targets.go
+++ b/pkg/types/targets.go
@@ -13,6 +13,7 @@ type TargetOptions struct {
 	RemoteUser       *string `json:"Remote User,omitempty"`
 	RemotePassword   *string `json:"Remote Password,omitempty"`
 	RemotePrivateKey *string `json:"Remote Private Key Path,omitempty"`
+	SockPath         *string `json:"Sock Path,omitempty"`
 }
 
 func GetTargetManifest() *provider.ProviderTargetManifest {
@@ -43,6 +44,10 @@ func GetTargetManifest() *provider.ProviderTargetManifest {
 			Type:              provider.ProviderTargetPropertyTypeFilePath,
 			DefaultValue:      "~/.ssh",
 			DisabledPredicate: "^local$",
+		},
+		"Sock Path": provider.ProviderTargetProperty{
+			Type:         provider.ProviderTargetPropertyTypeString,
+			DefaultValue: "/var/run/docker.sock",
 		},
 	}
 }


### PR DESCRIPTION
The sock file path is now a param of a target.

The default value is set to `/var/run/docker.sock`.

I have verified that this does not introduce a breaking change with older versions of the provider.

Closes #3 