### PR TITLE
Moving to prebuilt devcontainer.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:22.04
-
-ADD postcreate.sh /setup/postcreate.sh
-RUN chmod +x /setup/postcreate.sh
-
-RUN apt update -y && \
-    apt install curl protobuf-compiler libprotobuf-dev -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,7 @@
 {
 	"name": "Daytona Docker Provider",
-	"build": {
-		"dockerfile": "./Dockerfile"
-	},
-	"features": {
-		"ghcr.io/devcontainers/features/common-utils:1": {
-			"installZsh": "true",
-			"username": "daytona",
-			"uid": "1000",
-			"gid": "1000",
-			"upgradePackages": "false"
-		},
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.22.1"
-		},
-		"ghcr.io/devcontainers/features/node:1": {}
-	},
+    "image": "ghcr.io/daytonaio/go-devcontainer:main",
+
 	"containerEnv": {
 		"LOG_LEVEL": "debug"
 	},


### PR DESCRIPTION
Related to daytonaio/daytona#201 this moves to the prebuilt devcontainer. This can be shared across Daytona Go projects. Keeping code DRY, building fast, and downloading less.