### PR TITLE
fix: pass env to init command

### DIFF
--- a/pkg/provider/util/init_container.go
+++ b/pkg/provider/util/init_container.go
@@ -44,7 +44,7 @@ func InitContainer(client *client.Client, project *types.Project, workdirPath, i
 		},
 		User: "daytona",
 		Env:  envVars,
-		Cmd:  []string{"bash", "-c", fmt.Sprintf("curl -sf -L %s | sudo bash && daytona agent", serverDownloadUrl)},
+		Cmd:  []string{"bash", "-c", fmt.Sprintf("curl -sf -L %s | sudo -E bash && daytona agent", serverDownloadUrl)},
 	}, &container.HostConfig{
 		Privileged: true,
 		Binds: []string{


### PR DESCRIPTION
## Description

With this PR, the `-E` is added to the `sudo bash` init command. This is required to preserve shell environment variables which are used in the init command.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
