### PR TITLE
refactor: use project env vars provided by Daytona

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -197,11 +197,6 @@ func (p DockerProvider) CreateProject(projectReq *provider.ProjectRequest) (*typ
 		return new(types.Empty), errors.New("ServerApiUrl not set. Did you forget to call Initialize?")
 	}
 
-	serverVersion := "latest"
-	if p.ServerVersion != nil {
-		serverVersion = *p.ServerVersion
-	}
-
 	client, err := p.getClient(projectReq.TargetOptions)
 	if err != nil {
 		return new(types.Empty), err
@@ -223,7 +218,7 @@ func (p DockerProvider) CreateProject(projectReq *provider.ProjectRequest) (*typ
 		defer projectLogWriter.Close()
 	}
 
-	err = util.InitContainer(client, projectReq.Project, clonePath, targetOptions.ContainerImage, *p.ServerDownloadUrl, serverVersion, *p.ServerUrl, *p.ServerApiUrl)
+	err = util.InitContainer(client, projectReq.Project, clonePath, targetOptions.ContainerImage, *p.ServerDownloadUrl)
 	if err != nil {
 		return new(types.Empty), err
 	}

--- a/pkg/provider/util/init_container.go
+++ b/pkg/provider/util/init_container.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/client"
 )
 
-func InitContainer(client *client.Client, project *types.Project, workdirPath, imageName, serverDownloadUrl, serverVersion, serverUrl, serverApiUrl string) error {
+func InitContainer(client *client.Client, project *types.Project, workdirPath, imageName, serverDownloadUrl string) error {
 	ctx := context.Background()
 
 	mounts := []mount.Mount{
@@ -24,14 +24,11 @@ func InitContainer(client *client.Client, project *types.Project, workdirPath, i
 	}
 
 	envVars := []string{
-		"DAYTONA_WS_ID=" + project.WorkspaceId,
 		"DAYTONA_WS_DIR=" + path.Join("/workspaces", project.Name),
-		"DAYTONA_WS_PROJECT_NAME=" + project.Name,
-		"DAYTONA_WS_PROJECT_REPOSITORY_URL=" + project.Repository.Url,
-		"DAYTONA_SERVER_API_KEY=" + project.ApiKey,
-		"DAYTONA_SERVER_VERSION=" + serverVersion,
-		"DAYTONA_SERVER_URL=" + serverUrl,
-		"DAYTONA_SERVER_API_URL=" + serverApiUrl,
+	}
+
+	for key, value := range project.EnvVars {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
 	}
 
 	_, err := client.ContainerCreate(ctx, &container.Config{


### PR DESCRIPTION
# Project Env Vars from Daytona

## Description

The init container function now uses env variables provided by Daytona instead of maintaining them in the provider.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor, DX improvement

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings