### PR TITLE
fix: workspace creation log duplication

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -223,7 +223,14 @@ func (p DockerProvider) CreateProject(projectReq *provider.ProjectRequest) (*typ
 		return new(types.Empty), err
 	}
 
-	err = util.StartContainer(client, projectReq.Project, &logWriter)
+	go func() {
+		err := util.GetContainerLogs(client, util.GetContainerName(projectReq.Project), &logWriter)
+		if err != nil {
+			logWriter.Write([]byte(err.Error()))
+		}
+	}()
+
+	err = util.StartContainer(client, projectReq.Project, nil)
 	if err != nil {
 		return new(types.Empty), err
 	}

--- a/pkg/provider/util/container_logs.go
+++ b/pkg/provider/util/container_logs.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"context"
+	"io"
+
+	docker_types "github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+func GetContainerLogs(client *client.Client, containerName string, logWriter *io.Writer) error {
+	if logWriter == nil {
+		return nil
+	}
+
+	logs, err := client.ContainerLogs(context.Background(), containerName, docker_types.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+	})
+	if err != nil {
+		return err
+	}
+	defer logs.Close()
+
+	_, err = stdcopy.StdCopy(*logWriter, *logWriter, logs)
+
+	return err
+}


### PR DESCRIPTION
# Workspace Creation Log Fix

## Description

This PR fixes log duplication when creating a workspace. Additionally, the start project function will return early if the container is already started.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings