### PR TITLE
fix: get container logs after start

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -223,17 +223,17 @@ func (p DockerProvider) CreateProject(projectReq *provider.ProjectRequest) (*typ
 		return new(types.Empty), err
 	}
 
+	err = util.StartContainer(client, projectReq.Project, nil)
+	if err != nil {
+		return new(types.Empty), err
+	}
+
 	go func() {
 		err := util.GetContainerLogs(client, util.GetContainerName(projectReq.Project), &logWriter)
 		if err != nil {
 			logWriter.Write([]byte(err.Error()))
 		}
 	}()
-
-	err = util.StartContainer(client, projectReq.Project, nil)
-	if err != nil {
-		return new(types.Empty), err
-	}
 
 	err = util.WaitForBinaryDownload(client, projectReq.Project)
 	if err != nil {


### PR DESCRIPTION
# Get Project Logs After Start

## Description

With this PR, project logs are read after the container is started in the create project function. This ensures that the container logs request does go through.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings