### PR TITLE
fix: direct binary download

### DIFF
--- a/pkg/provider/create.go
+++ b/pkg/provider/create.go
@@ -67,17 +67,24 @@ func (p DockerProvider) CreateProject(projectReq *provider.ProjectRequest) (*pro
 	}
 
 	var sshClient *ssh.Client
-	if projectReq.Project.Target == "local" {
-		if projectReq.Project.BuildConfig == nil {
-			p.setLocalEnvOverride(projectReq.Project)
-		}
-	} else {
+	if projectReq.Project.Target != "local" {
 		sshClient, err = p.getSshClient(projectReq.Project.Target, projectReq.TargetOptions)
 		if err != nil {
 			return new(provider_util.Empty), err
 		}
 		defer sshClient.Close()
 	}
+	// TODO: think about how to handle this since the project is cloned in dockerClient.CreateProject so we can't detect the builder type here
+	// else {
+	// 	builderType, err := detect.DetectProjectBuilderType(projectReq.Project.BuildConfig, projectDir, nil)
+	// 	if err != nil {
+	// 		return new(provider_util.Empty), err
+	// 	}
+
+	// 	if builderType != detect.BuilderTypeDevcontainer {
+	// 		p.setLocalEnvOverride(projectReq.Project)
+	// 	}
+	// }
 
 	return new(provider_util.Empty), dockerClient.CreateProject(&docker.CreateProjectOptions{
 		Project:    projectReq.Project,


### PR DESCRIPTION
# Direct Binary Download

## Description

This PR fixes a regression with directly downloading the Daytona binary from the server (through `host.docker.internal`) when using the local target.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation