### PR TITLE
fix: rename default targets to preset targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The Docker Provider allows Daytona to create workspace projects as Docker contai
 | Remote Password         	| String   	| true     	|                             	| true        	| ^local$           	|
 | Remote Private Key Path 	| FilePath 	| true     	|                             	| false       	| ^local$           	|
 
-### Default Targets
+### Preset Targets
 
 #### Local
 | Property        	| Value                       	|

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.1
 
 require (
-	github.com/daytonaio/daytona v0.38.0
+	github.com/daytonaio/daytona v0.40.0
 	github.com/docker/docker v27.2.0+incompatible
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davidmz/go-pageant v1.0.2 h1:bPblRCh5jGU+Uptpz6LgMZGD5hJoOt7otgT454WvHn0=
 github.com/davidmz/go-pageant v1.0.2/go.mod h1:P2EDDnMqIwG5Rrp05dTRITj9z2zpGcD9efWSkTNKLIE=
-github.com/daytonaio/daytona v0.38.0 h1:T5EkDP8jf6GRPVHIExmfFLnNVunyjgobtcze4bdjmV8=
-github.com/daytonaio/daytona v0.38.0/go.mod h1:ZZ+sA66/4715zoWUbtpjNb2VfueJ8uHxCZAayUhDzAw=
+github.com/daytonaio/daytona v0.40.0 h1:+EUCUbKXJSP+QJOGglz38J8/Q9vtuItJb6YZx8Uv0p8=
+github.com/daytonaio/daytona v0.40.0/go.mod h1:ZZ+sA66/4715zoWUbtpjNb2VfueJ8uHxCZAayUhDzAw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v27.2.0+incompatible h1:Rk9nIVdfH3+Vz4cyI/uhbINhEZ/oLmc+CBXmH6fbNk4=

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -84,20 +84,20 @@ func (p DockerProvider) GetTargetManifest() (*provider.ProviderTargetManifest, e
 	return provider_types.GetTargetManifest(), nil
 }
 
-func (p DockerProvider) GetDefaultTargets() (*[]provider.ProviderTarget, error) {
+func (p DockerProvider) GetPresetTargets() (*[]provider.ProviderTarget, error) {
 	info, err := p.GetInfo()
 	if err != nil {
 		return nil, err
 	}
 
-	defaultTargets := []provider.ProviderTarget{
+	presetTargets := []provider.ProviderTarget{
 		{
 			Name:         "local",
 			ProviderInfo: info,
 			Options:      "{\n\t\"Sock Path\": \"/var/run/docker.sock\"\n}",
 		},
 	}
-	return &defaultTargets, nil
+	return &presetTargets, nil
 }
 
 func (p DockerProvider) StartWorkspace(workspaceReq *provider.WorkspaceRequest) (*provider_util.Empty, error) {


### PR DESCRIPTION
# Rename default targets to preset targets

## Description

Rename default targets to preset targets

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes
To merge after Daytona v0.40.0
