### PR TITLE
refactor: add no target mode property to provider info

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -75,9 +75,10 @@ func (p DockerProvider) GetInfo() (provider.ProviderInfo, error) {
 	label := "Docker"
 
 	return provider.ProviderInfo{
-		Name:    "docker-provider",
-		Label:   &label,
-		Version: internal.Version,
+		Name:            "docker-provider",
+		Label:           &label,
+		AgentlessTarget: true,
+		Version:         internal.Version,
 	}, nil
 }
 


### PR DESCRIPTION
# Add no target mode property to provider info
## Description

Adds NoTargetModeAgent property and sets it to true pointer

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
