### PR TITLE
refactor: add container registires as an array input

### DIFF
--- a/pkg/provider/create.go
+++ b/pkg/provider/create.go
@@ -82,13 +82,12 @@ func (p DockerProvider) CreateWorkspace(workspaceReq *provider.WorkspaceRequest)
 	}
 
 	return new(provider_util.Empty), dockerClient.CreateWorkspace(&docker.CreateWorkspaceOptions{
-		Workspace:                workspaceReq.Workspace,
-		WorkspaceDir:             workspaceDir,
-		ContainerRegistry:        workspaceReq.ContainerRegistry,
-		BuilderImage:             workspaceReq.BuilderImage,
-		BuilderContainerRegistry: workspaceReq.BuilderContainerRegistry,
-		LogWriter:                logWriter,
-		Gpc:                      workspaceReq.GitProviderConfig,
-		SshClient:                sshClient,
+		Workspace:           workspaceReq.Workspace,
+		WorkspaceDir:        workspaceDir,
+		ContainerRegistries: workspaceReq.ContainerRegistries,
+		BuilderImage:        workspaceReq.BuilderImage,
+		LogWriter:           logWriter,
+		Gpc:                 workspaceReq.GitProviderConfig,
+		SshClient:           sshClient,
 	})
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -190,14 +190,13 @@ func (p DockerProvider) StartWorkspace(workspaceReq *provider.WorkspaceRequest) 
 	}
 
 	err = dockerClient.StartWorkspace(&docker.CreateWorkspaceOptions{
-		Workspace:                workspaceReq.Workspace,
-		WorkspaceDir:             workspaceDir,
-		ContainerRegistry:        workspaceReq.ContainerRegistry,
-		BuilderImage:             workspaceReq.BuilderImage,
-		BuilderContainerRegistry: workspaceReq.BuilderContainerRegistry,
-		LogWriter:                logWriter,
-		Gpc:                      workspaceReq.GitProviderConfig,
-		SshClient:                sshClient,
+		Workspace:           workspaceReq.Workspace,
+		WorkspaceDir:        workspaceDir,
+		ContainerRegistries: workspaceReq.ContainerRegistries,
+		BuilderImage:        workspaceReq.BuilderImage,
+		LogWriter:           logWriter,
+		Gpc:                 workspaceReq.GitProviderConfig,
+		SshClient:           sshClient,
 	}, downloadUrl)
 	if err != nil {
 		return new(provider_util.Empty), err


### PR DESCRIPTION
# Add container registires as an array input

## Description

In this PR provider receives container registries as an array instead of receiving each container registry separately.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation